### PR TITLE
Modmail

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Saki bot for Gimai Seikatsu Discord Server",
   "main": "dist/index.js",
   "scripts": {
-    "prepare": "husky install && tsc",
+    "prepare": "husky install && prisma generate && tsc",
     "build": "tsc",
     "dev": "ts-node src",
     "start": "node .",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -65,6 +65,19 @@ model Cache {
   @@map("Cache")
 }
 
+// A model for modmail entries
+model Modmail {
+  threadId    String    @id @map("_id")
+  isOpen      Boolean   @default(true)
+  userId      String
+  createdById String
+  createdAt   DateTime  @default(now())
+  closedById  String?
+  closedAt    DateTime?
+
+  @@map("Modmail")
+}
+
 type Feed {
   link String
 }

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -4,7 +4,7 @@
  * This populates the database with the basic required entries, which are the
  * module entry and the cache. Run the following command to seed it:
  *
- *   $ npm run seed
+ *   $ npm run prs:seed
  *
  * More details at: https://www.prisma.io/docs/guides/database/seed-database
  */

--- a/src/commands/staff/modmail.ts
+++ b/src/commands/staff/modmail.ts
@@ -1,6 +1,7 @@
-import { SlashCommandBuilder } from 'discord.js';
+import { SlashCommandBuilder, type User } from 'discord.js';
 import type { Command } from '../../struct/types';
 import { log } from '../../util';
+import { closeMail, createMail } from '../../util/modmail';
 
 export const command: Command = {
 	data: new SlashCommandBuilder()
@@ -17,20 +18,80 @@ export const command: Command = {
 						.setRequired(true),
 				),
 		)
-		.addSubcommand((sub) => sub.setName('close').setDescription('Close an existing modmail')),
+		.addSubcommand((sub) =>
+			sub
+				.setName('close')
+				.setDescription('Close an existing modmail')
+				.addUserOption((option) =>
+					option
+						.setName('user')
+						.setDescription('The user whose modmail to close')
+						.setRequired(true),
+				),
+		),
 	async execute(interaction) {
-		await interaction.deferReply();
+		await interaction.deferReply({
+			ephemeral: true,
+		});
+		const user = interaction.options.getUser('user') as User;
+		const mail = await prisma.modmail.findFirst({
+			where: {
+				userId: user.id,
+				isOpen: true,
+			},
+		});
 		switch (interaction.options.getSubcommand()) {
 			case 'open': {
+				if (mail) {
+					interaction.editReply(
+						`A modmail for that user is already opened at <#${mail.threadId}>. Please use it or close that before opening a new one`,
+					);
+					return;
+				}
+				const success = user
+					.send({
+						embeds: [
+							{
+								color: 16105148,
+								title: 'Modmail Open',
+								description:
+									'A modmail channel has been opened with you by the Gimai Seikatsu staff team for dicussing a topic.\nYou can send messages here to reply back to them.',
+							},
+						],
+					})
+					.then(() => true)
+					.catch((e) => {
+						if (e.code === 50007) {
+							interaction.editReply(
+								'Unable the send modmail reply. The user has their dms disabled for this server. Please tell them to enable it first!',
+							);
+							return false;
+						}
+						log(e);
+						interaction.editReply('Unexpected error while trying to send modmail. Check logs');
+						return false;
+					});
+				if (!success) return;
+				await createMail(user, interaction.user.id);
+				interaction.editReply('Successfully created modmail');
 				return;
 			}
 
 			case 'close': {
+				if (!mail) {
+					interaction.editReply('No modmail for that user is currently opened.');
+					return;
+				}
+				await closeMail(mail.threadId, interaction.user);
+				interaction.editReply('Successfully closed modmail');
 				return;
 			}
 
 			default: {
-				log(interaction);
+				log({
+					message: 'Unknown subcommand received',
+					...interaction,
+				});
 				interaction.editReply('Unknown subcommand received. please report this to the dev');
 				return;
 			}

--- a/src/commands/staff/modmail.ts
+++ b/src/commands/staff/modmail.ts
@@ -1,0 +1,39 @@
+import { SlashCommandBuilder } from 'discord.js';
+import type { Command } from '../../struct/types';
+import { log } from '../../util';
+
+export const command: Command = {
+	data: new SlashCommandBuilder()
+		.setName('modmail')
+		.setDescription('Group of commands for modmail')
+		.addSubcommand((sub) =>
+			sub
+				.setName('open')
+				.setDescription('Start a new modmail with a user')
+				.addUserOption((option) =>
+					option
+						.setName('user')
+						.setDescription('The user to start the modmail with')
+						.setRequired(true),
+				),
+		)
+		.addSubcommand((sub) => sub.setName('close').setDescription('Close an existing modmail')),
+	async execute(interaction) {
+		await interaction.deferReply();
+		switch (interaction.options.getSubcommand()) {
+			case 'open': {
+				return;
+			}
+
+			case 'close': {
+				return;
+			}
+
+			default: {
+				log(interaction);
+				interaction.editReply('Unknown subcommand received. please report this to the dev');
+				return;
+			}
+		}
+	},
+};

--- a/src/events/guildMemberAdd.ts
+++ b/src/events/guildMemberAdd.ts
@@ -1,7 +1,7 @@
 import type { Event } from '../struct/types';
 import { Events, type GuildMember, type Client, GuildTextBasedChannel } from 'discord.js';
 import config from '../config';
-import { log } from '../util';
+import { dateTimestamp, log } from '../util';
 import { welcome } from '../modules/welcome';
 
 export const event: Event = {
@@ -45,7 +45,7 @@ export const event: Event = {
 					fields: [
 						{
 							name: 'Account Age',
-							value: `<t:${Math.ceil(member.user.createdAt.getTime() / 1000)}:R>`,
+							value: dateTimestamp(member.user.createdAt),
 						},
 					],
 				},

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -26,6 +26,8 @@ export const event: Event = {
 			case InteractionType.MessageComponent: {
 				if (!interaction.isButton()) return; // For now, we only handle buttons
 
+				if (!interaction.customId.startsWith('MOD')) return;
+
 				if (!isStaff(interaction.member as GuildMember)) {
 					interaction.reply({
 						content: 'Mod only usage',
@@ -33,8 +35,6 @@ export const event: Event = {
 					});
 					return;
 				}
-				if (!interaction.customId.startsWith('MOD')) return;
-
 				await interaction.deferUpdate();
 
 				const cid = interaction.customId.replace('MOD_', '');

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -1,6 +1,17 @@
+import {
+	Events,
+	ChannelType as CT,
+	type Message,
+	ActionRowBuilder,
+	ButtonBuilder,
+	ButtonStyle,
+	ComponentType,
+	type BaseGuildTextChannel,
+	time,
+} from 'discord.js';
 import type { Event } from '../struct/types';
-import { Events, ChannelType as CT, type Message } from 'discord.js';
 import config from '../config';
+import { log } from '../util';
 
 export const event: Event = {
 	name: Events.MessageCreate,
@@ -10,6 +21,155 @@ export const event: Event = {
 		switch (message.channel.type) {
 			case CT.DM: {
 				if (message.content.startsWith(';')) return;
+				const channel = (await client.channels
+					.fetch(config.channels.modmail)
+					.catch(log)) as BaseGuildTextChannel | null;
+				if (!channel) {
+					message.channel.send(
+						'Unexpected internal error when fetching modmail channel. Please report this to dev or try later.',
+					);
+					return;
+				}
+				let mail = await prisma.modmail.findFirst({
+					where: {
+						isOpen: true,
+						userId: message.author.id,
+					},
+				});
+
+				if (!mail) {
+					const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+						new ButtonBuilder()
+							.setLabel('YES')
+							.setStyle(ButtonStyle.Primary)
+							.setCustomId('mail_yes')
+							.setEmoji('✅'),
+						new ButtonBuilder()
+							.setLabel('NO')
+							.setStyle(ButtonStyle.Danger)
+							.setCustomId('mail_no')
+							.setEmoji('❌'),
+					);
+					const response = await message.channel.send({
+						embeds: [
+							{
+								title: 'Confirmation',
+								color: 16105148,
+								description: 'Do you want to open a modmail with the Gimai Staff Team?',
+								footer: {
+									text: 'Tip: Messages in dms starting with ; are ignored.',
+								},
+							},
+						],
+						components: [row],
+					});
+
+					const i = await response
+						.awaitMessageComponent({
+							componentType: ComponentType.Button,
+							time: 10 * 1000, // 10 seconds
+							filter: (b) => {
+								b.deferUpdate();
+								return b.user.id === message.author.id;
+							},
+						})
+						.catch(() => null);
+
+					if (!i || i.customId === 'mail_no') {
+						response.edit({
+							embeds: [
+								{
+									title: 'Process Cancelled',
+									color: 16105148,
+								},
+							],
+							components: [],
+						});
+						return;
+					}
+					response.edit({
+						embeds: [
+							{
+								color: 16105148,
+								title: 'Initiating modmail....',
+							},
+						],
+						components: [],
+					});
+					const userMails = await prisma.modmail.findMany({
+						where: {
+							userId: message.author.id,
+						},
+					});
+
+					const startMessage = await channel.send({
+						embeds: [
+							{
+								title: 'New Modmail',
+								color: 16105148,
+								fields: [
+									{
+										name: 'User Info',
+										value: `**Name**: ${message.author.tag}\n**Created at**: ${time(
+											message.author.createdTimestamp,
+										)}\n**Sent on:** ${time(message.createdTimestamp)}`,
+									},
+								],
+							},
+						],
+					});
+					const thread = await channel.threads
+						.create({
+							name: `${message.author.tag} ${userMails.length + 1}`,
+							reason: `Modmail by ${message.author.tag}`,
+							startMessage,
+						})
+						.catch(log);
+
+					if (!thread) {
+						message.edit('Unexpected error while creating modmail thread. Please report to dev');
+						return;
+					}
+					mail = await prisma.modmail
+						.create({
+							data: {
+								threadId: thread.id,
+								createdById: message.author.id,
+								userId: message.author.id,
+							},
+						})
+						.catch(log);
+					if (!mail) {
+						message.edit('Unexpected error while creating modmail entry. Please report to dev');
+						return;
+					}
+					response.edit({
+						embeds: [
+							{
+								description: 'Successfully created modmail!',
+								color: 16105148,
+							},
+						],
+					});
+				}
+				const thread = channel.threads.cache.find((x) => x.id === mail?.threadId);
+				if (!thread) {
+					message.edit('Unexpected error while finding modmail. Please report to dev');
+					return;
+				}
+				thread.send({
+					embeds: [
+						{
+							color: 5793266,
+							description: message.content,
+							author: {
+								name: message.author.tag,
+								icon_url: message.author.displayAvatarURL(),
+							},
+						},
+					],
+				});
+
 				return;
 			}
 
@@ -23,3 +183,28 @@ export const event: Event = {
 		}
 	},
 };
+
+// const collector = response.createMessageComponentCollector({
+//     componentType: ComponentType.Button,
+//     time: 10 * 1000,
+//     max: 1,
+// });
+// collector.on('collect', async button => {
+//     if (button.customId === 'mail_no') {
+
+//     }
+// });
+// collector.on('end', async (c) => {
+//     if (!c.size) {
+//         response.edit({
+//             embeds: [
+//                 {
+//                     title: 'Process Cancelled',
+//                     color: 16105148,
+//                 },
+//             ],
+//             components: []
+//         });
+//         leave = true;
+//     }
+// });

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -1,0 +1,25 @@
+import type { Event } from '../struct/types';
+import { Events, ChannelType as CT, type Message } from 'discord.js';
+import config from '../config';
+
+export const event: Event = {
+	name: Events.MessageCreate,
+	once: false,
+	async handle(message: Message) {
+		if (message.author.bot) return;
+		switch (message.channel.type) {
+			case CT.DM: {
+				if (message.content.startsWith(';')) return;
+				return;
+			}
+
+			case CT.GuildText: {
+				if (message.channelId !== config.channels.modmail) return;
+				return;
+			}
+
+			default:
+				return;
+		}
+	},
+};

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -98,7 +98,7 @@ export const event: Event = {
 					});
 
 					try {
-						mail = await createMail(message);
+						mail = await createMail(message.author);
 					} catch (e) {
 						response.edit(e as string);
 						return;

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -131,7 +131,7 @@ export const event: Event = {
 						.catch(log);
 
 					if (!thread) {
-						message.edit('Unexpected error while creating modmail thread. Please report to dev');
+						response.edit('Unexpected error while creating modmail thread. Please report to dev');
 						return;
 					}
 					mail = await prisma.modmail

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ const client = new DiscordClient({
 		Intents.GuildMessages,
 		Intents.GuildMessageReactions,
 		Intents.MessageContent,
+		Intents.DirectMessages,
 		Intents.GuildVoiceStates,
 	],
 	partials: [Partials.Message, Partials.Reaction, Partials.Channel],

--- a/src/util/discord.ts
+++ b/src/util/discord.ts
@@ -48,6 +48,13 @@ export async function sendLog(
 }
 
 /**
+ * Simple function that converts a date object to discord timestamp
+ *
+ * More at: https://discord.com/developers/docs/reference#message-formatting
+ */
+export const dateTimestamp = (d: Date) => `<t:${Math.ceil(d.getTime() / 1000)}:R>`;
+
+/**
  * Enums for log channels
  */
 export enum LogDestination {

--- a/src/util/discord.ts
+++ b/src/util/discord.ts
@@ -1,4 +1,10 @@
-import type { GuildMember, APIEmbed, JSONEncodable, TextChannel } from 'discord.js';
+import type {
+	GuildMember,
+	APIEmbed,
+	JSONEncodable,
+	TextChannel,
+	TimestampStylesString,
+} from 'discord.js';
 import config from '../config';
 import { log } from './logger';
 /**
@@ -52,7 +58,8 @@ export async function sendLog(
  *
  * More at: https://discord.com/developers/docs/reference#message-formatting
  */
-export const dateTimestamp = (d: Date) => `<t:${Math.ceil(d.getTime() / 1000)}:R>`;
+export const dateTimestamp = (d: Date, type: TimestampStylesString = 'R') =>
+	`<t:${Math.ceil(d.getTime() / 1000)}:${type}>`;
 
 /**
  * Enums for log channels

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -20,4 +20,5 @@ export function log(p: unknown) {
 		console.error(p);
 	}
 	logger.error(p);
+	return null;
 }

--- a/src/util/modmail.ts
+++ b/src/util/modmail.ts
@@ -1,0 +1,120 @@
+import type { Message, BaseGuildTextChannel, APIEmbed } from 'discord.js';
+import config from '../config';
+import { dateTimestamp } from './discord';
+import { log } from './logger';
+
+/**
+ * Utility function to create a new modmail
+ */
+export async function createMail(message: Message) {
+	const channel = (await client.channels
+		.fetch(config.channels.modmail)
+		.catch(log)) as BaseGuildTextChannel | null;
+
+	if (!channel) {
+		throw 'Unexpected internal error when fetching modmail channel. Please report this to dev or try later.';
+	}
+	const userMails = await prisma.modmail.findMany({
+		where: {
+			userId: message.author.id,
+		},
+	});
+	const startMessage = await channel.send({
+		embeds: [
+			{
+				title: 'New Modmail',
+				color: 16105148,
+				description: `${message.author.tag} <@${message.author.id}>`,
+				fields: [
+					{
+						name: 'Created',
+						value: dateTimestamp(message.author.createdAt),
+						inline: true,
+					},
+					{
+						name: 'ID',
+						value: message.author.id,
+						inline: true,
+					},
+				],
+			},
+		],
+	});
+	const thread = await channel.threads
+		.create({
+			name: `${message.author.tag} - ${userMails.length + 1}`,
+			reason: `Modmail by ${message.author.tag}`,
+			startMessage,
+		})
+		.catch(log);
+
+	if (!thread) {
+		throw 'Unexpected error while creating modmail thread. Please report to dev';
+	}
+	const mail = await prisma.modmail
+		.create({
+			data: {
+				threadId: thread.id,
+				createdById: message.author.id,
+				userId: message.author.id,
+			},
+		})
+		.catch(log);
+
+	if (!mail) {
+		throw 'Unexpected error while creating modmail entry. Please report to dev';
+	}
+	return mail;
+}
+
+/**
+ * Utility function to close modmails
+ */
+export async function closeMail(threadId: string) {
+	const mail = await prisma.modmail.findUnique({
+		where: {
+			threadId,
+		},
+	});
+	if (!mail) throw 'No modmail with that id exists';
+	if (!mail.isOpen) throw 'Modmail is already closed';
+	const channel = (await client.channels.fetch(
+		config.channels.modmail,
+	)) as BaseGuildTextChannel | null;
+	if (!channel) throw 'Missing modmail channel. Was the channel deleted?';
+
+	const embed: APIEmbed = {
+		title: 'Closing Thread',
+		color: 16105148,
+		description:
+			'Thank you for reaching out to the moderator team. Feel free to open another modmail if you need in the future.\nHappy to help!',
+	};
+	const thread = channel.threads.cache.find((x) => x.id === mail.threadId);
+	if (thread && !thread.archived) {
+		thread.send({
+			embeds: [
+				{
+					...embed,
+					description:
+						'Closed modmail. Use the `/modmail open` command to start a new modmail again.',
+				},
+			],
+		});
+		thread.setArchived(true).catch(log);
+	}
+	const user = await client.users.fetch(mail.createdById).catch(log);
+	user
+		?.send({
+			embeds: [embed],
+		})
+		.catch(log);
+
+	await prisma.modmail
+		.delete({
+			where: {
+				threadId: mail.threadId,
+			},
+		})
+		.catch(log);
+	return;
+}

--- a/src/util/modmail.ts
+++ b/src/util/modmail.ts
@@ -70,7 +70,7 @@ export async function createMail(author: User, createrId?: string) {
 /**
  * Utility function to close modmails
  */
-export async function closeMail(threadId: string) {
+export async function closeMail(threadId: string, closer: User) {
 	const mail = await prisma.modmail.findUnique({
 		where: {
 			threadId,
@@ -91,7 +91,7 @@ export async function closeMail(threadId: string) {
 	};
 	const thread = channel.threads.cache.find((x) => x.id === mail.threadId);
 	if (thread && !thread.archived) {
-		thread.send({
+		await thread.send({
 			embeds: [
 				{
 					...embed,
@@ -110,9 +110,14 @@ export async function closeMail(threadId: string) {
 		.catch(log);
 
 	await prisma.modmail
-		.delete({
+		.update({
 			where: {
 				threadId: mail.threadId,
+			},
+			data: {
+				isOpen: false,
+				closedAt: new Date(),
+				closedById: closer.id,
 			},
 		})
 		.catch(log);


### PR DESCRIPTION
This pr introduces the modmail features of the bot. A bi-directional modmail that enables staff and users to communicate with each other throught the bot.

- Slash commands to open & close modmails
- Allowing users to create new modmail if none exists when sending a message
- Ignore messages starting with `;`