### PR TITLE
Undici switch

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "dotenv": "^16.0.3",
     "ffmpeg-static": "^4.4.1",
     "libsodium-wrappers": "0.7.10",
-    "node-fetch": "2.6.7",
     "pino": "^7.11.0",
     "sourcebin": "^5.0.0",
     "tslib": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -30,27 +30,27 @@
     "@discordjs/opus": "^0.8.0",
     "@discordjs/voice": "^0.14.0",
     "@distube/yt-dlp": "^1.1.3",
-    "@napi-rs/canvas": "^0.1.30",
+    "@napi-rs/canvas": "^0.1.34",
     "@naval-base/ms": "^3.1.0",
-    "@prisma/client": "^4.8.1",
-    "discord.js": "^14.6.0",
+    "@prisma/client": "^4.9.0",
+    "discord.js": "^14.7.1",
     "distube": "^4.0.4",
     "dotenv": "^16.0.3",
-    "ffmpeg-static": "^4.2.7",
+    "ffmpeg-static": "^4.4.1",
     "libsodium-wrappers": "0.7.10",
     "node-fetch": "2.6.7",
-    "pino": "^7.0.0-rc.9",
+    "pino": "^7.11.0",
     "sourcebin": "^5.0.0",
-    "tslib": "^2.4.1",
-    "undici": "^5.14.0"
+    "tslib": "^2.5.0",
+    "undici": "^5.16.0"
   },
   "devDependencies": {
-    "@types/node": "^18.11.9",
+    "@types/node": "^18.11.18",
     "@types/node-fetch": "^2.6.2",
     "husky": "^8.0.3",
-    "prisma": "^4.8.1",
+    "prisma": "^4.9.0",
     "rome": "^11.0.0",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.3"
+    "typescript": "^4.9.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,53 +4,53 @@ specifiers:
   '@discordjs/opus': ^0.8.0
   '@discordjs/voice': ^0.14.0
   '@distube/yt-dlp': ^1.1.3
-  '@napi-rs/canvas': ^0.1.30
+  '@napi-rs/canvas': ^0.1.34
   '@naval-base/ms': ^3.1.0
-  '@prisma/client': ^4.8.1
-  '@types/node': ^18.11.9
+  '@prisma/client': ^4.9.0
+  '@types/node': ^18.11.18
   '@types/node-fetch': ^2.6.2
-  discord.js: ^14.6.0
+  discord.js: ^14.7.1
   distube: ^4.0.4
   dotenv: ^16.0.3
-  ffmpeg-static: ^4.2.7
+  ffmpeg-static: ^4.4.1
   husky: ^8.0.3
   libsodium-wrappers: 0.7.10
   node-fetch: 2.6.7
-  pino: ^7.0.0-rc.9
-  prisma: ^4.8.1
+  pino: ^7.11.0
+  prisma: ^4.9.0
   rome: ^11.0.0
   sourcebin: ^5.0.0
   ts-node: ^10.9.1
-  tslib: ^2.4.1
-  typescript: ^4.9.3
-  undici: ^5.14.0
+  tslib: ^2.5.0
+  typescript: ^4.9.4
+  undici: ^5.16.0
 
 dependencies:
   '@discordjs/opus': 0.8.0
-  '@discordjs/voice': 0.14.0_3wslz6lhjlue5uxffz7bjp32lq
+  '@discordjs/voice': 0.14.0_kj4b63tl655kaqafvjfrgtykda
   '@distube/yt-dlp': 1.1.3_distube@4.0.4
-  '@napi-rs/canvas': 0.1.30
+  '@napi-rs/canvas': 0.1.34
   '@naval-base/ms': 3.1.0
-  '@prisma/client': 4.8.1_prisma@4.8.1
-  discord.js: 14.6.0
-  distube: 4.0.4_hcklommxnjsmgvhilgcuzjrjji
+  '@prisma/client': 4.9.0_prisma@4.9.0
+  discord.js: 14.7.1
+  distube: 4.0.4_thv5uqmr5lbx7vu44ilwu3dme4
   dotenv: 16.0.3
-  ffmpeg-static: 4.2.7
+  ffmpeg-static: 4.4.1
   libsodium-wrappers: 0.7.10
   node-fetch: 2.6.7
   pino: 7.11.0
   sourcebin: 5.0.0
-  tslib: 2.4.1
-  undici: 5.14.0
+  tslib: 2.5.0
+  undici: 5.16.0
 
 devDependencies:
-  '@types/node': 18.11.9
+  '@types/node': 18.11.18
   '@types/node-fetch': 2.6.2
   husky: 8.0.3
-  prisma: 4.8.1
+  prisma: 4.9.0
   rome: 11.0.0
-  ts-node: 10.9.1_wup25etrarvlqkprac7h35hj7u
-  typescript: 4.9.3
+  ts-node: 10.9.1_awa2wsr5thmg3i7jqycphctjfq
+  typescript: 4.9.4
 
 packages:
 
@@ -71,20 +71,20 @@ packages:
       parse-cache-control: 1.0.1
     dev: false
 
-  /@discordjs/builders/1.3.0:
-    resolution: {integrity: sha512-Pvca6Nw8Hp+n3N+Wp17xjygXmMvggbh5ywUsOYE2Et4xkwwVRwgzxDJiMUuYapPtnYt4w/8aKlf5khc8ipLvhg==}
+  /@discordjs/builders/1.4.0:
+    resolution: {integrity: sha512-nEeTCheTTDw5kO93faM1j8ZJPonAX86qpq/QVoznnSa8WWcCgJpjlu6GylfINTDW6o7zZY0my2SYdxx2mfNwGA==}
     engines: {node: '>=16.9.0'}
     dependencies:
       '@discordjs/util': 0.1.0
-      '@sapphire/shapeshift': 3.7.0
-      discord-api-types: 0.37.19
+      '@sapphire/shapeshift': 3.8.1
+      discord-api-types: 0.37.30
       fast-deep-equal: 3.1.3
       ts-mixer: 6.0.2
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
 
-  /@discordjs/collection/1.2.0:
-    resolution: {integrity: sha512-VvrrtGb7vbfPHzbhGq9qZB5o8FOB+kfazrxdt0OtxzSkoBuw9dURMkCwWizZ00+rDpiK2HmLHBZX+y6JsG9khw==}
+  /@discordjs/collection/1.3.0:
+    resolution: {integrity: sha512-ylt2NyZ77bJbRij4h9u/wVy7qYw/aDqQLWnadjvDqW/WoWCxrsX6M3CIw9GVP5xcGCDxsrKj5e0r5evuFYwrKg==}
     engines: {node: '>=16.9.0'}
     dev: false
 
@@ -118,18 +118,18 @@ packages:
       - supports-color
     dev: false
 
-  /@discordjs/rest/1.3.0:
-    resolution: {integrity: sha512-U6X5J+r/MxYpPTlHFuPxXEf92aKsBaD2teBC7sWkKILIr30O8c9+XshfL7KFBCavnAqS/qE+PF9fgRilO3N44g==}
+  /@discordjs/rest/1.5.0:
+    resolution: {integrity: sha512-lXgNFqHnbmzp5u81W0+frdXN6Etf4EUi8FAPcWpSykKd8hmlWh1xy6BmE0bsJypU1pxohaA8lQCgp70NUI3uzA==}
     engines: {node: '>=16.9.0'}
     dependencies:
-      '@discordjs/collection': 1.2.0
+      '@discordjs/collection': 1.3.0
       '@discordjs/util': 0.1.0
       '@sapphire/async-queue': 1.5.0
-      '@sapphire/snowflake': 3.2.2
-      discord-api-types: 0.37.19
-      file-type: 18.0.0
-      tslib: 2.4.1
-      undici: 5.14.0
+      '@sapphire/snowflake': 3.4.0
+      discord-api-types: 0.37.30
+      file-type: 18.2.0
+      tslib: 2.5.0
+      undici: 5.16.0
     dev: false
 
   /@discordjs/util/0.1.0:
@@ -137,15 +137,15 @@ packages:
     engines: {node: '>=16.9.0'}
     dev: false
 
-  /@discordjs/voice/0.14.0_3wslz6lhjlue5uxffz7bjp32lq:
+  /@discordjs/voice/0.14.0_kj4b63tl655kaqafvjfrgtykda:
     resolution: {integrity: sha512-/LV8LSFuJ1c4OEW1ubPg3al2QNpUpwX8ZL+KL+LORmnUFVCtehSaEh+38uDfWg1O/TgiGI5vOLj4ZKql43drcw==}
     engines: {node: '>=16.9.0'}
     dependencies:
-      '@types/ws': 8.5.3
-      discord-api-types: 0.37.28
-      prism-media: 1.3.4_3wslz6lhjlue5uxffz7bjp32lq
-      tslib: 2.4.1
-      ws: 8.11.0
+      '@types/ws': 8.5.4
+      discord-api-types: 0.37.30
+      prism-media: 1.3.4_kj4b63tl655kaqafvjfrgtykda
+      tslib: 2.5.0
+      ws: 8.12.0
     transitivePeerDependencies:
       - '@discordjs/opus'
       - bufferutil
@@ -163,10 +163,10 @@ packages:
       distube: 3.x||4.x
     dependencies:
       dargs: 7.0.0
-      distube: 4.0.4_hcklommxnjsmgvhilgcuzjrjji
+      distube: 4.0.4_thv5uqmr5lbx7vu44ilwu3dme4
       execa: 5.1.1
       mkdirp: 1.0.4
-      undici: 5.14.0
+      undici: 5.16.0
     dev: false
 
   /@distube/ytdl-core/4.11.7:
@@ -208,8 +208,8 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.14
     dev: true
 
-  /@napi-rs/canvas-android-arm64/0.1.30:
-    resolution: {integrity: sha512-RaJvfg5x8QV+3WVqxwi1dt05mqiDuQF/w4wj8b6SHbxbVLfzZ5T0M9PFBTvjNU88GxiiVYUihxJeCCDs1sXP0g==}
+  /@napi-rs/canvas-android-arm64/0.1.34:
+    resolution: {integrity: sha512-oj6zoaLG3Re3EpKSaXy6rkYpw+dCiqFSpl2JL/uWZ5F2oB3A9KKL3wydQljgg8D40I6wEFAyUpbYgTU4q14quQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [android]
@@ -217,8 +217,8 @@ packages:
     dev: false
     optional: true
 
-  /@napi-rs/canvas-darwin-arm64/0.1.30:
-    resolution: {integrity: sha512-ZWW7+YYGFREzeV1uoGv0uUx+0OhGd5jQ6zFdaGYFESUjmLlfZ/LS0CG/IlbWDiWbnRPu2HQl0/TOQHurleJjLw==}
+  /@napi-rs/canvas-darwin-arm64/0.1.34:
+    resolution: {integrity: sha512-P8oEeRHJ5z2TYg+rHtEk5lxdODtvYKwfs3v8Uy5EuQJ7PIoEFjUfQnnntuZ1LwbDz0TfuaJz0aRH9TjMNnBKBw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -226,8 +226,8 @@ packages:
     dev: false
     optional: true
 
-  /@napi-rs/canvas-darwin-x64/0.1.30:
-    resolution: {integrity: sha512-DThro7Y3QFV/9bl/EORWXzBMXeIZU1jo80oI8Ha2Xsoy3Eq+wHhnlMyvNYcLjalxIFU/JJrzu6/qxjPaVzcw5A==}
+  /@napi-rs/canvas-darwin-x64/0.1.34:
+    resolution: {integrity: sha512-TptzmEvPbQtZQfpdVqXzvvyy0gRIxFSeaavUJEA0wstuXmMEEL3Ge6rk/lX38ixrwC6rTB3V6e2hziRd1UZ9Pg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
@@ -235,8 +235,8 @@ packages:
     dev: false
     optional: true
 
-  /@napi-rs/canvas-linux-arm-gnueabihf/0.1.30:
-    resolution: {integrity: sha512-bMz85lH3y2JL7Xf8szu/EayyEffN2FSAUtxOm6U3/MLc7jW2Pt8TRhAQQxnv0zNh8ub7qBDky+LspMBPLTDRzA==}
+  /@napi-rs/canvas-linux-arm-gnueabihf/0.1.34:
+    resolution: {integrity: sha512-w54DIqvdxc+cIP3y0esC26G5BKICE4nvo6J0u/q9zZruvnLkInKariAOMTN0gmDjZjHY3a5lTro4CTg0Odoteg==}
     engines: {node: '>= 10'}
     cpu: [arm]
     os: [linux]
@@ -244,8 +244,8 @@ packages:
     dev: false
     optional: true
 
-  /@napi-rs/canvas-linux-arm64-gnu/0.1.30:
-    resolution: {integrity: sha512-KHUVFOaG7wE4/GGTLk434GH7DIhPa7hhfMyzLqU1QFRXzjo0KIyO9gecHEF9snXaqvD4c/8YubEtFbWZVMSKUw==}
+  /@napi-rs/canvas-linux-arm64-gnu/0.1.34:
+    resolution: {integrity: sha512-N008ta7zer8v3cky4YLT9IcOmVmL7PyJ2P7L65GeICfOkczOD9THdgcbPWa6NNbHiDSHPSsXVRRrb5uAIDNbZQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -253,8 +253,8 @@ packages:
     dev: false
     optional: true
 
-  /@napi-rs/canvas-linux-arm64-musl/0.1.30:
-    resolution: {integrity: sha512-9ckRCQbt/ZVNbHvApKhvaRM+mahMl4xryV0vUEKgFHo8Fm4j56dPZRWeKojmk1vSGC9ahY73K1MEb0OaIxOv0Q==}
+  /@napi-rs/canvas-linux-arm64-musl/0.1.34:
+    resolution: {integrity: sha512-/axLA9UrNri93JqlbQaZ4Md2zUMwWxSHnTnlOnGBpDrAvFHrZ8VgYvQU6SbaiAuC7NvqADFgZ+lINo2JCMl1tw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -262,8 +262,8 @@ packages:
     dev: false
     optional: true
 
-  /@napi-rs/canvas-linux-x64-gnu/0.1.30:
-    resolution: {integrity: sha512-NSyhCClsTBs06ViivDU0lSGVTDBBtm3pSTQKZseAnBEEF0vuO4De5SJl4JYng9eSDQ6KqA4TkOZFUMxokP6ZVg==}
+  /@napi-rs/canvas-linux-x64-gnu/0.1.34:
+    resolution: {integrity: sha512-YEYdWWmAdZt/02t22DFlqFxANmmEI6/Vyqoz+7+Y6s/6nAohQ/S9qRjeYtMYW4J6qxSpoVhOm8NkZ7niv4OFJA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -271,8 +271,8 @@ packages:
     dev: false
     optional: true
 
-  /@napi-rs/canvas-linux-x64-musl/0.1.30:
-    resolution: {integrity: sha512-hT3sPij6nHKiH10avrd8MNwLYEBzwiVyzA0nxPosGJ+ErWk1tgE4UeM3w1+BWYK3S/wgY/4WlhxDgsd9crUGRA==}
+  /@napi-rs/canvas-linux-x64-musl/0.1.34:
+    resolution: {integrity: sha512-K4Nk/BL6TiLkMU8QAH45j/YAn7B4//cp6FvivGJBr7/unEm+nv8nSFX/ueBV9G6/lyOBKcWdiMWoclJxVP9q4A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -280,8 +280,8 @@ packages:
     dev: false
     optional: true
 
-  /@napi-rs/canvas-win32-x64-msvc/0.1.30:
-    resolution: {integrity: sha512-6MwkIMd53jNqO+KAvv2A7TtMY1MYE51VCdF7sZ61sypgjB/dOYmYqDgAU/RTHS5agyc0CZUeXoaZT43Lkgk67A==}
+  /@napi-rs/canvas-win32-x64-msvc/0.1.34:
+    resolution: {integrity: sha512-k8tPRVbB0svxC3sZ1qxMJbJYjnFN1oyi344DwbbOeUTUQNyGPwrpsHjtnPbNogl0/i/jFtRXH6fI5fCngmolCA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -289,27 +289,27 @@ packages:
     dev: false
     optional: true
 
-  /@napi-rs/canvas/0.1.30:
-    resolution: {integrity: sha512-XRR6PumJW9GdODD+HFW7ZKmpq7FE6PIKWn7QTcsJUdGNb54fTS1Z47oPFZ3pbvs07Xs8ZnkR03Q/9T3LfkGRgg==}
+  /@napi-rs/canvas/0.1.34:
+    resolution: {integrity: sha512-Nw719Ne/523nRIsM3ZHRfZFHKLE7Hy8K0ChQZNvOP4GebLBmeoySzEIaxxG4xja+jDGwhkbh43raMK7No9kx7A==}
     engines: {node: '>= 10'}
     optionalDependencies:
-      '@napi-rs/canvas-android-arm64': 0.1.30
-      '@napi-rs/canvas-darwin-arm64': 0.1.30
-      '@napi-rs/canvas-darwin-x64': 0.1.30
-      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.30
-      '@napi-rs/canvas-linux-arm64-gnu': 0.1.30
-      '@napi-rs/canvas-linux-arm64-musl': 0.1.30
-      '@napi-rs/canvas-linux-x64-gnu': 0.1.30
-      '@napi-rs/canvas-linux-x64-musl': 0.1.30
-      '@napi-rs/canvas-win32-x64-msvc': 0.1.30
+      '@napi-rs/canvas-android-arm64': 0.1.34
+      '@napi-rs/canvas-darwin-arm64': 0.1.34
+      '@napi-rs/canvas-darwin-x64': 0.1.34
+      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.34
+      '@napi-rs/canvas-linux-arm64-gnu': 0.1.34
+      '@napi-rs/canvas-linux-arm64-musl': 0.1.34
+      '@napi-rs/canvas-linux-x64-gnu': 0.1.34
+      '@napi-rs/canvas-linux-x64-musl': 0.1.34
+      '@napi-rs/canvas-win32-x64-msvc': 0.1.34
     dev: false
 
   /@naval-base/ms/3.1.0:
     resolution: {integrity: sha512-3xSG3J2f9xSEgni7liDFBNnlhOf6/sLedCMaEtWv3iaJkeaWvyfdWBYhd2bTko3BLMcQfY4MgICoUGRla1bXiQ==}
     dev: false
 
-  /@prisma/client/4.8.1_prisma@4.8.1:
-    resolution: {integrity: sha512-d4xhZhETmeXK/yZ7K0KcVOzEfI5YKGGEr4F5SBV04/MU4ncN/HcE28sy3e4Yt8UFW0ZuImKFQJE+9rWt9WbGSQ==}
+  /@prisma/client/4.9.0_prisma@4.9.0:
+    resolution: {integrity: sha512-bz6QARw54sWcbyR1lLnF2QHvRW5R/Jxnbbmwh3u+969vUKXtBkXgSgjDA85nji31ZBlf7+FrHDy5x+5ydGyQDg==}
     engines: {node: '>=14.17'}
     requiresBuild: true
     peerDependencies:
@@ -318,16 +318,16 @@ packages:
       prisma:
         optional: true
     dependencies:
-      '@prisma/engines-version': 4.8.0-61.d6e67a83f971b175a593ccc12e15c4a757f93ffe
-      prisma: 4.8.1
+      '@prisma/engines-version': 4.9.0-42.ceb5c99003b99c9ee2c1d2e618e359c14aef2ea5
+      prisma: 4.9.0
     dev: false
 
-  /@prisma/engines-version/4.8.0-61.d6e67a83f971b175a593ccc12e15c4a757f93ffe:
-    resolution: {integrity: sha512-MHSOSexomRMom8QN4t7bu87wPPD+pa+hW9+71JnVcF3DqyyO/ycCLhRL1we3EojRpZxKvuyGho2REQsMCvxcJw==}
+  /@prisma/engines-version/4.9.0-42.ceb5c99003b99c9ee2c1d2e618e359c14aef2ea5:
+    resolution: {integrity: sha512-M16aibbxi/FhW7z1sJCX8u+0DriyQYY5AyeTH7plQm9MLnURoiyn3CZBqAyIoQ+Z1pS77usCIibYJWSgleBMBA==}
     dev: false
 
-  /@prisma/engines/4.8.1:
-    resolution: {integrity: sha512-93tctjNXcIS+i/e552IO6tqw17sX8liivv8WX9lDMCpEEe3ci+nT9F+1oHtAafqruXLepKF80i/D20Mm+ESlOw==}
+  /@prisma/engines/4.9.0:
+    resolution: {integrity: sha512-t1pt0Gsp+HcgPJrHFc+d/ZSAaKKWar2G/iakrE07yeKPNavDP3iVKPpfXP22OTCHZUWf7OelwKJxQgKAm5hkgw==}
     requiresBuild: true
 
   /@rometools/cli-darwin-arm64/11.0.0:
@@ -383,16 +383,16 @@ packages:
     engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
     dev: false
 
-  /@sapphire/shapeshift/3.7.0:
-    resolution: {integrity: sha512-A6vI1zJoxhjWo4grsxpBRBgk96SqSdjLX5WlzKp9H+bJbkM07mvwcbtbVAmUZHbi/OG3HLfiZ1rlw4BhH6tsBQ==}
+  /@sapphire/shapeshift/3.8.1:
+    resolution: {integrity: sha512-xG1oXXBhCjPKbxrRTlox9ddaZTvVpOhYLmKmApD/vIWOV1xEYXnpoFs68zHIZBGbqztq6FrUPNPerIrO1Hqeaw==}
     engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
     dependencies:
       fast-deep-equal: 3.1.3
-      lodash.uniqwith: 4.5.0
+      lodash: 4.17.21
     dev: false
 
-  /@sapphire/snowflake/3.2.2:
-    resolution: {integrity: sha512-ula2O0kpSZtX9rKXNeQMrHwNd7E4jPDJYUXmEGTFdMRfyfMw+FPyh04oKMjAiDuOi64bYgVkOV3MjK+loImFhQ==}
+  /@sapphire/snowflake/3.4.0:
+    resolution: {integrity: sha512-zZxymtVO6zeXVMPds+6d7gv/OfnCc25M1Z+7ZLB0oPmeMTPeRWVPQSS16oDJy5ZsyCOLj7M6mbZml5gWXcVRNw==}
     engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
     dev: false
 
@@ -423,7 +423,7 @@ packages:
   /@types/node-fetch/2.6.2:
     resolution: {integrity: sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==}
     dependencies:
-      '@types/node': 18.11.9
+      '@types/node': 18.11.18
       form-data: 3.0.1
     dev: true
 
@@ -431,13 +431,13 @@ packages:
     resolution: {integrity: sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==}
     dev: false
 
-  /@types/node/18.11.9:
-    resolution: {integrity: sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==}
+  /@types/node/18.11.18:
+    resolution: {integrity: sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==}
 
-  /@types/ws/8.5.3:
-    resolution: {integrity: sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==}
+  /@types/ws/8.5.4:
+    resolution: {integrity: sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==}
     dependencies:
-      '@types/node': 18.11.9
+      '@types/node': 18.11.18
     dev: false
 
   /abbrev/1.1.1:
@@ -449,8 +449,8 @@ packages:
     engines: {node: '>=0.4.0'}
     dev: true
 
-  /acorn/8.8.1:
-    resolution: {integrity: sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==}
+  /acorn/8.8.2:
+    resolution: {integrity: sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
     dev: true
@@ -610,36 +610,32 @@ packages:
     engines: {node: '>=0.3.1'}
     dev: true
 
-  /discord-api-types/0.37.19:
-    resolution: {integrity: sha512-5dVUYJfxCh/RU/S4D7osG3H+Ntl0GBkANO6oVRl35Eo+cd/peoNUAmcSzLzQ9Fqu2RJ9+2vd7DVcqNqYjX38wQ==}
+  /discord-api-types/0.37.30:
+    resolution: {integrity: sha512-TzNF28zWV63clYW1+rbKT2+2qSI+lw/aNG3lyP2fIj5NioGPz4C+bCSvwhP3Ly3uLwL7v8FxIiu8XKGDsvuwWA==}
     dev: false
 
-  /discord-api-types/0.37.28:
-    resolution: {integrity: sha512-K0fw7m7km9th3dCQ2AR90q/FwX3uAj+OLc+Zuo39VY9vCn0Ux/iObM4y1zJYIH3vTc+QlrksVErUvyeONjOKMQ==}
-    dev: false
-
-  /discord.js/14.6.0:
-    resolution: {integrity: sha512-On1K7xpJZRe0KsziIaDih2ksYPhgxym/ZqV45i1f3yig4vUotikqs7qp5oXiTzQ/UTiNRCixUWFTh7vA1YBCqw==}
+  /discord.js/14.7.1:
+    resolution: {integrity: sha512-1FECvqJJjjeYcjSm0IGMnPxLqja/pmG1B0W2l3lUY2Gi4KXiyTeQmU1IxWcbXHn2k+ytP587mMWqva2IA87EbA==}
     engines: {node: '>=16.9.0'}
     dependencies:
-      '@discordjs/builders': 1.3.0
-      '@discordjs/collection': 1.2.0
-      '@discordjs/rest': 1.3.0
+      '@discordjs/builders': 1.4.0
+      '@discordjs/collection': 1.3.0
+      '@discordjs/rest': 1.5.0
       '@discordjs/util': 0.1.0
-      '@sapphire/snowflake': 3.2.2
-      '@types/ws': 8.5.3
-      discord-api-types: 0.37.19
+      '@sapphire/snowflake': 3.4.0
+      '@types/ws': 8.5.4
+      discord-api-types: 0.37.30
       fast-deep-equal: 3.1.3
       lodash.snakecase: 4.1.1
-      tslib: 2.4.1
-      undici: 5.14.0
-      ws: 8.11.0
+      tslib: 2.5.0
+      undici: 5.16.0
+      ws: 8.12.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
     dev: false
 
-  /distube/4.0.4_hcklommxnjsmgvhilgcuzjrjji:
+  /distube/4.0.4_thv5uqmr5lbx7vu44ilwu3dme4:
     resolution: {integrity: sha512-Y/CePsz7pVeOXR6H40L+oHCERlMFO4eZYjrzQcGYrC0m+dTgp5OGseCUmwyWX1bjdSZdFHn4WMZ9yXvt1vJgjA==}
     engines: {node: '>=16.9.0'}
     peerDependencies:
@@ -651,15 +647,15 @@ packages:
         optional: true
     dependencies:
       '@discordjs/opus': 0.8.0
-      '@discordjs/voice': 0.14.0_3wslz6lhjlue5uxffz7bjp32lq
+      '@discordjs/voice': 0.14.0_kj4b63tl655kaqafvjfrgtykda
       '@distube/ytdl-core': 4.11.7
       '@distube/ytpl': 1.1.1
       '@distube/ytsr': 1.1.9
-      discord.js: 14.6.0
-      prism-media: '@codeload.github.com/distubejs/prism-media/tar.gz/main#workaround.tar.gz_3wslz6lhjlue5uxffz7bjp32lq'
+      discord.js: 14.7.1
+      prism-media: '@codeload.github.com/distubejs/prism-media/tar.gz/main#workaround.tar.gz_kj4b63tl655kaqafvjfrgtykda'
       tiny-typed-emitter: 2.1.0
-      tslib: 2.4.1
-      undici: 5.14.0
+      tslib: 2.5.0
+      undici: 5.16.0
     transitivePeerDependencies:
       - ffmpeg-static
       - node-opus
@@ -719,8 +715,8 @@ packages:
     engines: {node: '>=6'}
     dev: false
 
-  /ffmpeg-static/4.2.7:
-    resolution: {integrity: sha512-SGnOr2d+k0/9toRIv9t5/hN/DMYbm5XMtG0wVwGM1tEyXJAD6dbcWOEvfHq4LOySm9uykKL6LMC4eVPeteUnbQ==}
+  /ffmpeg-static/4.4.1:
+    resolution: {integrity: sha512-gyGTIf5kgmLDmH7Rwj8vMmNK46bjXKKofHS2gY+LUqoTe/iybVuTuvnhJQR2tZHlKlDG7A/BIH7cRa2jWDKgWw==}
     engines: {node: '>=10'}
     requiresBuild: true
     dependencies:
@@ -732,8 +728,8 @@ packages:
       - supports-color
     dev: false
 
-  /file-type/18.0.0:
-    resolution: {integrity: sha512-jjMwFpnW8PKofLE/4ohlhqwDk5k0NC6iy0UHAJFKoY1fQeGMN0GDdLgHQrvCbSpMwbqzoCZhRI5dETCZna5qVA==}
+  /file-type/18.2.0:
+    resolution: {integrity: sha512-M3RQMWY3F2ykyWZ+IHwNCjpnUmukYhtdkGGC1ZVEUb0ve5REGF7NNJ4Q9ehCUabtQKtSVFOMbFTXgJlFb0DQIg==}
     engines: {node: '>=14.16'}
     dependencies:
       readable-web-to-node-stream: 3.0.2
@@ -885,8 +881,8 @@ packages:
     resolution: {integrity: sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==}
     dev: false
 
-  /lodash.uniqwith/4.5.0:
-    resolution: {integrity: sha512-7lYL8bLopMoy4CTICbxygAUq6CdRJ36vFc80DucPueUee+d5NBRxz3FdT9Pes/HEx5mPoT9jwnsEJWz1N7uq7Q==}
+  /lodash/4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
     dev: false
 
   /lru-cache/6.0.0:
@@ -1081,12 +1077,12 @@ packages:
       process-warning: 1.0.0
       quick-format-unescaped: 4.0.4
       real-require: 0.1.0
-      safe-stable-stringify: 2.4.1
+      safe-stable-stringify: 2.4.2
       sonic-boom: 2.8.0
       thread-stream: 0.15.2
     dev: false
 
-  /prism-media/1.3.4_3wslz6lhjlue5uxffz7bjp32lq:
+  /prism-media/1.3.4_kj4b63tl655kaqafvjfrgtykda:
     resolution: {integrity: sha512-eW7LXORkTCQznZs+eqe9VjGOrLBxcBPXgNyHXMTSRVhphvd/RrxgIR7WaWt4fkLuhshcdT5KHL88LAfcvS3f5g==}
     peerDependencies:
       '@discordjs/opus': ^0.8.0
@@ -1104,16 +1100,16 @@ packages:
         optional: true
     dependencies:
       '@discordjs/opus': 0.8.0
-      ffmpeg-static: 4.2.7
+      ffmpeg-static: 4.4.1
     dev: false
 
-  /prisma/4.8.1:
-    resolution: {integrity: sha512-ZMLnSjwulIeYfaU1O6/LF6PEJzxN5par5weykxMykS9Z6ara/j76JH3Yo2AH3bgJbPN4Z6NeCK9s5fDkzf33cg==}
+  /prisma/4.9.0:
+    resolution: {integrity: sha512-bS96oZ5oDFXYgoF2l7PJ3Mp1wWWfLOo8B/jAfbA2Pn0Wm5Z/owBHzaMQKS3i1CzVBDWWPVnOohmbJmjvkcHS5w==}
     engines: {node: '>=14.17'}
     hasBin: true
     requiresBuild: true
     dependencies:
-      '@prisma/engines': 4.8.1
+      '@prisma/engines': 4.9.0
 
   /process-warning/1.0.0:
     resolution: {integrity: sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==}
@@ -1174,8 +1170,8 @@ packages:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
     dev: false
 
-  /safe-stable-stringify/2.4.1:
-    resolution: {integrity: sha512-dVHE6bMtS/bnL2mwualjc6IxEv1F+OCUpA46pKUj6F8uDbUM0jCCulPqRNPSnWwGNKx5etqMjZYdXtrm5KJZGA==}
+  /safe-stable-stringify/2.4.2:
+    resolution: {integrity: sha512-gMxvPJYhP0O9n2pvcfYfIuYgbledAOJFcqRThtPRmjscaipiwcwPPKLytpVzMkG2HAN87Qmo2d4PtGiri1dSLA==}
     engines: {node: '>=10'}
     dev: false
 
@@ -1318,7 +1314,7 @@ packages:
     resolution: {integrity: sha512-zvHx3VM83m2WYCE8XL99uaM7mFwYSkjR2OZti98fabHrwkjsCvgwChda5xctein3xGOyaQhtTeDq/1H/GNvF3A==}
     dev: false
 
-  /ts-node/10.9.1_wup25etrarvlqkprac7h35hj7u:
+  /ts-node/10.9.1_awa2wsr5thmg3i7jqycphctjfq:
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -1337,34 +1333,34 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
-      '@types/node': 18.11.9
-      acorn: 8.8.1
+      '@types/node': 18.11.18
+      acorn: 8.8.2
       acorn-walk: 8.2.0
       arg: 4.1.3
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 4.9.3
+      typescript: 4.9.4
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     dev: true
 
-  /tslib/2.4.1:
-    resolution: {integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==}
+  /tslib/2.5.0:
+    resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
     dev: false
 
   /typedarray/0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
     dev: false
 
-  /typescript/4.9.3:
-    resolution: {integrity: sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==}
+  /typescript/4.9.4:
+    resolution: {integrity: sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: true
 
-  /undici/5.14.0:
-    resolution: {integrity: sha512-yJlHYw6yXPPsuOH0x2Ib1Km61vu4hLiRRQoafs+WUgX1vO64vgnxiCEN9dpIrhZyHFsai3F0AEj4P9zy19enEQ==}
+  /undici/5.16.0:
+    resolution: {integrity: sha512-KWBOXNv6VX+oJQhchXieUznEmnJMqgXMbs0xxH2t8q/FUAWSJvOSr/rMaZKnX5RIVq7JDn0JbP4BOnKG2SGXLQ==}
     engines: {node: '>=12.18'}
     dependencies:
       busboy: 1.6.0
@@ -1407,12 +1403,12 @@ packages:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
     dev: false
 
-  /ws/8.11.0:
-    resolution: {integrity: sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==}
+  /ws/8.12.0:
+    resolution: {integrity: sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
-      utf-8-validate: ^5.0.2
+      utf-8-validate: '>=5.0.2'
     peerDependenciesMeta:
       bufferutil:
         optional: true
@@ -1429,7 +1425,7 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  '@codeload.github.com/distubejs/prism-media/tar.gz/main#workaround.tar.gz_3wslz6lhjlue5uxffz7bjp32lq':
+  '@codeload.github.com/distubejs/prism-media/tar.gz/main#workaround.tar.gz_kj4b63tl655kaqafvjfrgtykda':
     resolution: {tarball: https://codeload.github.com/distubejs/prism-media/tar.gz/main#workaround.tar.gz}
     id: '@codeload.github.com/distubejs/prism-media/tar.gz/main#workaround.tar.gz'
     name: prism-media
@@ -1450,5 +1446,5 @@ packages:
         optional: true
     dependencies:
       '@discordjs/opus': 0.8.0
-      ffmpeg-static: 4.2.7
+      ffmpeg-static: 4.4.1
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,6 @@ specifiers:
   ffmpeg-static: ^4.4.1
   husky: ^8.0.3
   libsodium-wrappers: 0.7.10
-  node-fetch: 2.6.7
   pino: ^7.11.0
   prisma: ^4.9.0
   rome: ^11.0.0
@@ -37,7 +36,6 @@ dependencies:
   dotenv: 16.0.3
   ffmpeg-static: 4.4.1
   libsodium-wrappers: 0.7.10
-  node-fetch: 2.6.7
   pino: 7.11.0
   sourcebin: 5.0.0
   tslib: 2.5.0

--- a/rome.json
+++ b/rome.json
@@ -6,6 +6,9 @@
       "recommended": true,
       "style": {
         "useTemplate": "off"
+      },
+      "suspicious": {
+        "noExplicitAny": "off"
       }
     }
   },

--- a/src/commands/member/about.ts
+++ b/src/commands/member/about.ts
@@ -1,7 +1,7 @@
 import { SlashCommandBuilder } from 'discord.js';
 import type { Command } from '../../struct/types';
 const { version } = require('../../../package.json') as { version: string };
-import fetch from 'node-fetch';
+import { fetch } from 'undici';
 
 export const command: Command = {
 	data: new SlashCommandBuilder().setName('about').setDescription('Information about the bot'),
@@ -12,7 +12,7 @@ export const command: Command = {
 				const json = await response.json();
 				return response.ok ? json : Promise.reject(json);
 			})
-			.then((res) => res);
+			.then((res) => res as Record<string, any>[]);
 
 		const arr = [];
 		for (const commit of commits) {

--- a/src/commands/member/fact.ts
+++ b/src/commands/member/fact.ts
@@ -1,19 +1,16 @@
 import { SlashCommandBuilder } from 'discord.js';
 import type { Command } from '../../struct/types';
-import fetch from 'node-fetch';
+import { fetch } from 'undici';
 import { log } from '../../util';
 
 export const command: Command = {
 	data: new SlashCommandBuilder().setName('fact').setDescription('Sends a random Maaya fact'),
 	async execute(interaction) {
 		await interaction.deferReply();
-		const fact: string | null = await fetch('https://nekos.life/api/v2/fact')
-			.then((res) => res.json())
+		const fact = await fetch('https://nekos.life/api/v2/fact')
+			.then((res) => res.json() as Promise<Record<string, string>>)
 			.then((res) => res.fact)
-			.catch((e) => {
-				log(e);
-				return null;
-			});
+			.catch(log);
 
 		if (!fact) {
 			interaction.editReply('Unexpected error. Could not fetch result for api.');

--- a/src/commands/member/meme.ts
+++ b/src/commands/member/meme.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
-import fetch from 'node-fetch';
+import { fetch } from 'undici';
 import type { Command } from '../../struct/types';
 import { log, rand } from '../../util';
 
@@ -23,7 +23,7 @@ export const command: Command = {
 		}
 		const memes = await fetch(`https://reddit.com/r/${subs[rand(0, 1)]}.json?limit=100&sort=new`)
 			.then((v) => v.json())
-			.then((v) => v.data.children)
+			.then((v) => (v as Record<string, any>).data.children)
 			.then((v) => v.map((d: Record<string, string>) => d.data))
 			.then((v) => v.filter((a: Record<string, string>) => a.post_hint === 'image'))
 			.catch((e) => {

--- a/src/jobs/chapters.ts
+++ b/src/jobs/chapters.ts
@@ -1,7 +1,7 @@
 import { Collection, GuildTextBasedChannel } from 'discord.js';
 import config from '../config';
 import { type Job } from '../struct/types';
-import fetch from 'node-fetch';
+import { fetch } from 'undici';
 import { log } from '../util';
 
 export const job: Job = {
@@ -55,10 +55,7 @@ async function getChaps() {
 
 	const v = await fetch('https://cclawtranslations.home.blog/feed/')
 		.then((v) => v.text())
-		.catch((e) => {
-			log(e);
-			return null;
-		});
+		.catch(log);
 
 	const map = new Collection<string, string>();
 	if (!v) return map;

--- a/src/jobs/mangadex.ts
+++ b/src/jobs/mangadex.ts
@@ -2,7 +2,7 @@ import { GuildTextBasedChannel } from 'discord.js';
 import config from '../config';
 import type { Job } from '../struct/types';
 import { log } from '../util';
-import fetch from 'node-fetch';
+import { fetch } from 'undici';
 
 export const job: Job = {
 	name: 'Mangadex',

--- a/src/jobs/reddit.ts
+++ b/src/jobs/reddit.ts
@@ -1,5 +1,5 @@
 import { Job } from '../struct/types';
-import fetch from 'node-fetch';
+import { fetch } from 'undici';
 import config from '../config';
 import { APIEmbed, GuildTextBasedChannel } from 'discord.js';
 import { log } from '../util';
@@ -10,7 +10,7 @@ export const job: Job = {
 	async run() {
 		const embeds = (await fetch('https://www.reddit.com/r/GimaiSeikatsu/new.json?sort=new&limit=10')
 			.then((v) => v.json())
-			.then((v) => v.data.children.reverse())
+			.then((v) => (v as Record<string, any>).data.children.reverse())
 			.then((v) => v.map((d: Record<string, string>) => d.data))
 			.then(iterate)
 			.catch((e) => {

--- a/src/jobs/twitter.ts
+++ b/src/jobs/twitter.ts
@@ -1,5 +1,5 @@
 import { Job } from '../struct/types';
-import fetch from 'node-fetch';
+import { fetch } from 'undici';
 import { log } from '../util';
 import config from '../config';
 import { GuildTextBasedChannel } from 'discord.js';
@@ -18,14 +18,11 @@ export const job: Job = {
 			},
 		)
 			.then(async (v) => await v.json())
-			.then((v) => v.data)
+			.then((v) => (v as Record<string, Record<string, string>[]>).data)
 			.then((v) =>
 				v.map((r: Record<string, string>) => `https://twitter.com/gimaiseikatsu/status/${r.id}`),
 			)
-			.catch((e) => {
-				log(e);
-				return null;
-			});
+			.catch(log);
 
 		if (!res?.length) return;
 		const feeds = await prisma.cache

--- a/src/jobs/youtube.ts
+++ b/src/jobs/youtube.ts
@@ -1,19 +1,19 @@
 import { Job } from '../struct/types';
 import { log } from '../util';
 import config from '../config';
-import { GuildTextBasedChannel } from 'discord.js';
-import fetch from 'node-fetch';
+import { type GuildTextBasedChannel } from 'discord.js';
+import { fetch } from 'undici';
 
 export const job: Job = {
 	name: 'Youtube',
 	// Once every 15 mins
 	interval: 15 * 60,
 	async run() {
-		const res: YoutubeResult = await fetch(
+		const res = await fetch(
 			`https://www.googleapis.com/youtube/v3/search?key=${process.env.YOUTUBE_API_KEY}&channelId=UCOQyW7GmCyTKwjCJEaTBWRw&part=snippet,id&order=date&maxResults=1`,
 		)
 			.then((r) => r.json())
-			.then((r) => r.items[0]);
+			.then((r) => (r as Record<string, YoutubeResult[]>).items[0]);
 
 		const link = `https://youtu.be/${res.id.videoId}`;
 		const feeds = await prisma.cache


### PR DESCRIPTION
Switch to using undici from node-fetch
- undici is more lighter (around 1.5 mb?) than node-fetch (around 7mb)
- node-fetch was used cz prev djs internally used node-fetch so i didnt wanna add another  extra dep when node-fetch was gonna be in the proj no matter what
- djs itself uses undici under the hood instead of node-fetch, so it removes an extra dep and uses an existing one
- undici is being maintained by the core nodejs team so it should be okay.